### PR TITLE
feat: expose more outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This action implements `POST` request to `/repos/{owner}/{repo}/releases`
   run: |
     echo ${{ steps.my_step_id.outputs.id }}
     echo ${{ steps.my_step_id.outputs.number }}
+    echo ${{ steps.my_step_id.outputs.url }}
+    echo ${{ steps.my_step_id.outputs.html_url }}
+    echo ${{ steps.my_step_id.outputs.assets_url }}
+    echo ${{ steps.my_step_id.outputs.upload_url }}
 ```
 
 
@@ -44,6 +48,10 @@ This action implements `POST` request to `/repos/{owner}/{repo}/releases`
 |---|---|
 |id|`id` field of the response (if exists)|
 |number|`number` field of the response (if exists)|
+|url|`url` field of the response (if exists)|
+|html_url|`html_url` field of the response (if exists)|
+|assets_url|`assets_url` field of the response (if exists)|
+|upload_url|`upload_url` field of the response (if exists)|
 
 # Friendly octions
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 const core = require("@actions/core");
 const { request } = require("@octokit/request");
-const github = require("@actions/github")
+const github = require("@actions/github");
 
 function parse_array(input_name) {
-  const input_value = core.getInput(input_name)
+  const input_value = core.getInput(input_name);
   if (input_value === "") {
-    return undefined; 
+    return undefined;
   }
   if (input_value === "<<EMPTY>>") {
     return [];
@@ -14,20 +14,20 @@ function parse_array(input_name) {
 }
 
 function parse_boolean(input_name) {
-  const input_value = core.getInput(input_name)
-  return input_value === "true"
+  const input_value = core.getInput(input_name);
+  return input_value === "true";
 }
 
 function default_parse(input_name) {
-  const input_value = core.getInput(input_name)
+  const input_value = core.getInput(input_name);
   if (!input_value) {
-    if (input_name === 'owner') {
-      return github.context.repo.owner
-    } else if (input_name === 'repo') {
-      return github.context.repo.repo
+    if (input_name === "owner") {
+      return github.context.repo.owner;
+    } else if (input_name === "repo") {
+      return github.context.repo.repo;
     }
   }
-  return input_value || undefined
+  return input_value || undefined;
 }
 
 const token = default_parse("token");
@@ -40,34 +40,48 @@ const body = default_parse("body");
 const draft = parse_boolean("draft");
 const prerelease = parse_boolean("prerelease");
 
-
 const requestWithAuth = request.defaults({
   headers: {
-    authorization: `Bearer ${token}`
+    authorization: `Bearer ${token}`,
   },
 });
 
 requestWithAuth("post /repos/{owner}/{repo}/releases", {
-    token,
-    owner,
-    repo,
-    tag_name,
-    target_commitish,
-    name,
-    body,
-    draft,
-    prerelease,
+  token,
+  owner,
+  repo,
+  tag_name,
+  target_commitish,
+  name,
+  body,
+  draft,
+  prerelease,
 })
-  .then(result => {
+  .then((result) => {
     console.log("result", result);
-    if (result && result.data && result.data.id) {
-      core.setOutput('id', result.data.id)
-    }
-    if (result && result.data && result.data.number) {
-      core.setOutput('number', result.data.number)
+
+    if (result && result.data) {
+      if (result.data.id) {
+        core.setOutput("id", result.data.id);
+      }
+      if (result.data.number) {
+        core.setOutput("number", result.data.number);
+      }
+      if (result.data.url) {
+        core.setOutput("url", result.data.url);
+      }
+      if (result.data.html_url) {
+        core.setOutput("html_url", result.data.html_url);
+      }
+      if (result.data.assets_url) {
+        core.setOutput("assets_url", result.data.assets_url);
+      }
+      if (result.data.upload_url) {
+        core.setOutput("upload_url", result.data.upload_url);
+      }
     }
   })
-  .catch(error => {
+  .catch((error) => {
     console.log("error", error);
     core.setFailed(error.message);
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oction-create-release",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "index.js",
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
Hello there!

Thank you for this nice action - anyhow, I would personally need to access the `upload_url` of the created release to upload some assets.

So, I added the most common urls I've seen used by other actions to the outputs. :)

Let me know what you think.

Cheers!